### PR TITLE
feat: add working directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 > GitHub Action for install npm dependencies with caching without any configuration
 
-See [bahmutov/npm-install-action-example](https://github.com/bahmutov/npm-install-action-example).
+## Examples
+
+### Basic
+
+This example should cover 95% of use cases.
 
 If you use `npm ci` or `yarn --frozen-lockfile` on CI to install NPM dependencies - this Action is for you. Simply use it, and your NPM modules will be installed and the folder `~/.npm` or `~/.cache/yarn` will be cached. Typical use:
 
@@ -18,6 +22,48 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm t
 ```
+
+See [bahmutov/npm-install-action-example](https://github.com/bahmutov/npm-install-action-example).
+
+### Subfolders
+
+If your repository contains packages in separate folders, install each one separately
+
+```text
+repo/
+  app1/
+    package-lock.json
+  app2/
+    yarn.json
+```
+
+```yml
+name: main
+on: [push]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    name: Build and test
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: app1
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: app2
+
+      - name: App1 tests
+        run: npm t
+        working-directory: app1
+      - name: Run app2
+        run: node .
+        working-directory: app2
+```
+
+See [npm-install-monorepo-example](https://github.com/bahmutov/npm-install-monorepo-example).
 
 ## NPM
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -985,7 +985,10 @@ const core = __webpack_require__(470)
 const exec = __webpack_require__(986)
 const io = __webpack_require__(1)
 const hasha = __webpack_require__(309)
-const { restoreCache, saveCache } = __webpack_require__(211)
+const {
+  restoreCache,
+  saveCache
+} = __webpack_require__(211)
 const fs = __webpack_require__(747)
 const os = __webpack_require__(87)
 const path = __webpack_require__(622)
@@ -993,8 +996,20 @@ const quote = __webpack_require__(531)
 
 const homeDirectory = os.homedir()
 
-const useYarn = fs.existsSync('yarn.lock')
-const lockFilename = useYarn ? 'yarn.lock' : 'package-lock.json'
+const workingDirectory =
+  core.getInput('working-directory') || process.cwd()
+const yarnFilename = path.join(
+  workingDirectory,
+  'yarn.lock'
+)
+const packageLockFilename = path.join(
+  workingDirectory,
+  'package-lock.json'
+)
+const useYarn = fs.existsSync(yarnFilename)
+const lockFilename = useYarn
+  ? yarnFilename
+  : packageLockFilename
 const lockHash = hasha.fromFileSync(lockFilename)
 const platformAndArch = `${process.platform}-${process.arch}`
 
@@ -1024,7 +1039,10 @@ const restoreCachedNpm = () => {
 
 const saveCachedNpm = () => {
   console.log('saving NPM modules')
-  return saveCache(NPM_CACHE.inputPath, NPM_CACHE.primaryKey)
+  return saveCache(
+    NPM_CACHE.inputPath,
+    NPM_CACHE.primaryKey
+  )
 }
 
 const install = () => {
@@ -1035,11 +1053,16 @@ const install = () => {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(quote(yarnPath), ['--frozen-lockfile'])
+      return exec.exec(quote(yarnPath), [
+        '--frozen-lockfile'
+      ])
     })
   } else {
     console.log('installing NPM dependencies')
-    core.exportVariable('npm_config_cache', NPM_CACHE_FOLDER)
+    core.exportVariable(
+      'npm_config_cache',
+      NPM_CACHE_FOLDER
+    )
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)

--- a/dist/index.js
+++ b/dist/index.js
@@ -1019,12 +1019,11 @@ const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = `yarn-${platformAndArch}-`
+    o.primaryKey = o.restoreKeys = `yarn-${platformAndArch}-${lockHash}`
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = `npm-${platformAndArch}-`
+    o.primaryKey = o.restoreKeys = `npm-${platformAndArch}-${lockHash}`
   }
-  o.primaryKey = o.restoreKeys + lockHash
   return o
 })()
 
@@ -1049,13 +1048,19 @@ const install = () => {
   // Note: need to quote found tool to avoid Windows choking on
   // npm paths with spaces like "C:\Program Files\nodejs\npm.cmd ci"
 
+  const options = {
+    cwd: workingDirectory
+  }
+
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(quote(yarnPath), [
-        '--frozen-lockfile'
-      ])
+      return exec.exec(
+        quote(yarnPath),
+        ['--frozen-lockfile'],
+        options
+      )
     })
   } else {
     console.log('installing NPM dependencies')
@@ -1066,7 +1071,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(quote(npmPath), ['ci'])
+      return exec.exec(quote(npmPath), ['ci'], options)
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -37,12 +37,11 @@ const NPM_CACHE = (() => {
   const o = {}
   if (useYarn) {
     o.inputPath = path.join(homeDirectory, '.cache', 'yarn')
-    o.restoreKeys = `yarn-${platformAndArch}-`
+    o.primaryKey = o.restoreKeys = `yarn-${platformAndArch}-${lockHash}`
   } else {
     o.inputPath = NPM_CACHE_FOLDER
-    o.restoreKeys = `npm-${platformAndArch}-`
+    o.primaryKey = o.restoreKeys = `npm-${platformAndArch}-${lockHash}`
   }
-  o.primaryKey = o.restoreKeys + lockHash
   return o
 })()
 
@@ -67,13 +66,19 @@ const install = () => {
   // Note: need to quote found tool to avoid Windows choking on
   // npm paths with spaces like "C:\Program Files\nodejs\npm.cmd ci"
 
+  const options = {
+    cwd: workingDirectory
+  }
+
   if (useYarn) {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(quote(yarnPath), [
-        '--frozen-lockfile'
-      ])
+      return exec.exec(
+        quote(yarnPath),
+        ['--frozen-lockfile'],
+        options
+      )
     })
   } else {
     console.log('installing NPM dependencies')
@@ -84,7 +89,7 @@ const install = () => {
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)
-      return exec.exec(quote(npmPath), ['ci'])
+      return exec.exec(quote(npmPath), ['ci'], options)
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@ const core = require('@actions/core')
 const exec = require('@actions/exec')
 const io = require('@actions/io')
 const hasha = require('hasha')
-const { restoreCache, saveCache } = require('cache/lib/index')
+const {
+  restoreCache,
+  saveCache
+} = require('cache/lib/index')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
@@ -11,8 +14,20 @@ const quote = require('quote')
 
 const homeDirectory = os.homedir()
 
-const useYarn = fs.existsSync('yarn.lock')
-const lockFilename = useYarn ? 'yarn.lock' : 'package-lock.json'
+const workingDirectory =
+  core.getInput('working-directory') || process.cwd()
+const yarnFilename = path.join(
+  workingDirectory,
+  'yarn.lock'
+)
+const packageLockFilename = path.join(
+  workingDirectory,
+  'package-lock.json'
+)
+const useYarn = fs.existsSync(yarnFilename)
+const lockFilename = useYarn
+  ? yarnFilename
+  : packageLockFilename
 const lockHash = hasha.fromFileSync(lockFilename)
 const platformAndArch = `${process.platform}-${process.arch}`
 
@@ -42,7 +57,10 @@ const restoreCachedNpm = () => {
 
 const saveCachedNpm = () => {
   console.log('saving NPM modules')
-  return saveCache(NPM_CACHE.inputPath, NPM_CACHE.primaryKey)
+  return saveCache(
+    NPM_CACHE.inputPath,
+    NPM_CACHE.primaryKey
+  )
 }
 
 const install = () => {
@@ -53,11 +71,16 @@ const install = () => {
     console.log('installing NPM dependencies using Yarn')
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
-      return exec.exec(quote(yarnPath), ['--frozen-lockfile'])
+      return exec.exec(quote(yarnPath), [
+        '--frozen-lockfile'
+      ])
     })
   } else {
     console.log('installing NPM dependencies')
-    core.exportVariable('npm_config_cache', NPM_CACHE_FOLDER)
+    core.exportVariable(
+      'npm_config_cache',
+      NPM_CACHE_FOLDER
+    )
 
     return io.which('npm', true).then(npmPath => {
       console.log('npm at "%s"', npmPath)


### PR DESCRIPTION
- closes #2

For repos like
```text
repo/
  app1/
    package-lock.json
  app2/
    yarn.json
```

```yml
name: main
on: [push]

jobs:
  build-and-test:
    runs-on: ubuntu-latest
    name: Build and test
    steps:
      - uses: actions/checkout@v1

      - uses: bahmutov/npm-install@v1
        with:
          working-directory: app1
      - uses: bahmutov/npm-install@v1
        with:
          working-directory: app2

      - name: App1 tests
        run: npm t
        working-directory: app1
      - name: Run app2
        run: node .
        working-directory: app2
```