### PR TITLE
fix: add missing inputs in action.yaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,3 +8,10 @@ runs:
 branding:
   color: 'yellow'
   icon: 'command'
+inputs:
+  working-directory:
+    description: 'Working directory to specify subfolder in which dependencies are defined'
+    required: false
+  useLockFile:
+    description: 'Option to enable or disable use of a lock file (package-lock.json/yarn.lock)'
+    required: false


### PR DESCRIPTION
This one fixes warning about "Unexpected input" during build:
```
##[warning]Unexpected input 'working-directory', valid inputs are ['']
```
as described in #30 

@bahmutov I also added `useLockFile` prop as I see it can be used from docs. Therefore I assume somebody will got similar error in the future. If you have better description texts let me know and I will change them. 