### PR TITLE
fix: saveCache shouldn't error on existing cache, warn instead

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -1,5 +1,5 @@
 name: example-basic
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-subfolders.yml
+++ b/.github/workflows/example-subfolders.yml
@@ -1,5 +1,5 @@
 name: example-subfolders
-on: [push]
+on: [push, pull_request]
 jobs:
   separate-actions:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/example-without-lock-file.yml
+++ b/.github/workflows/example-without-lock-file.yml
@@ -1,5 +1,5 @@
 name: example-without-lock-file
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-yarn.yml
+++ b/.github/workflows/example-yarn.yml
@@ -1,5 +1,5 @@
 name: example-yarn
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: main
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-and-test:

--- a/dist/index.js
+++ b/dist/index.js
@@ -2756,7 +2756,19 @@ const restoreCachedNpm = npmCache => {
 
 const saveCachedNpm = npmCache => {
   console.log('saving NPM modules')
-  return cache.saveCache(npmCache.inputPaths, npmCache.primaryKey)
+
+  return cache
+    .saveCache(npmCache.inputPaths, npmCache.primaryKey)
+    .catch(err => {
+      // don't throw an error if cache already exists, which may happen due to
+      // race conditions
+      if (err.message.includes('Cache already exists')) {
+        console.warn(err.message)
+        return -1
+      }
+      // otherwise re-throw
+      throw err
+    })
 }
 
 const hasOption = (name, o) => name in o

--- a/index.js
+++ b/index.js
@@ -38,7 +38,19 @@ const restoreCachedNpm = npmCache => {
 
 const saveCachedNpm = npmCache => {
   console.log('saving NPM modules')
-  return cache.saveCache(npmCache.inputPaths, npmCache.primaryKey)
+
+  return cache
+    .saveCache(npmCache.inputPaths, npmCache.primaryKey)
+    .catch(err => {
+      // don't throw an error if cache already exists, which may happen due to
+      // race conditions
+      if (err.message.includes('Cache already exists')) {
+        console.warn(err.message)
+        return -1
+      }
+      // otherwise re-throw
+      throw err
+    })
 }
 
 const hasOption = (name, o) => name in o


### PR DESCRIPTION
## Description

### Commits

#### hotfix: saveCache shouldn't error on existing cache, warn instead

- if your workflow has a race condition where similar jobs with the same
  cache key run in parallel, one will saveCache first and the next will
  error out when trying to saveCache
  - previously this was a warning, but after upgrading to official
    @actions/cache, it is now an error
  - this can occur on matrix installs with similar enough environments
    (e.g. different Node version, same OS) and did occur in workflows
    here too actually
    - there's an upstream issue tracking this, so it might actually have
      a different root cause

####  ci: also run all workflows on PRs to ensure they pass
    
- previously only ran on `push`, meaning only for root repo branches,
  and not PRs from forks
  - meaning they could be failing unknowingly and it would only be seen
    _after_ merge
    - as happened with my previous PR
  - this should make it run on PRs from forks as well, so failed CI
    checks should be very visible
    - (but branch protection needs to be turned on to prevent merging)

## Tags

Fixes #39 , workaround for upstream https://github.com/actions/cache/issues/144
Follow-up to bug introduced by #37 

Adding PR check to CI pretty much identical to https://github.com/formium/tsdx/pull/373

## Review Notes

#37 passed the CI check / self-integration test matrix I added in my fork ~and I believe it passed here too (says 0 checks now though, possibly due to the patch bump added there)~, but when it was merged here [it then failed](https://github.com/bahmutov/npm-install/runs/967446119). Since then has caused many failures downstream per #39, which I too experienced

**EDIT**: nope, CI checks didn't run here as they weren't turned on for PRs, so I've added that to all CI checks now as a second commit in this PR

## Testing

### Screenshot differences in CI

Before [on `master`](https://github.com/bahmutov/npm-install/runs/967446119):

![Screen Shot 2020-08-14 at 2 29 22 AM](https://user-images.githubusercontent.com/4970083/90220475-46df4a80-ddd6-11ea-8828-b32db78f4f3b.png)


After [on cache-busted version of current PR](https://github.com/agilgur5/npm-install/runs/983738078?check_suite_focus=true):

![Screen Shot 2020-08-14 at 2 43 05 AM](https://user-images.githubusercontent.com/4970083/90221372-17314200-ddd8-11ea-8d15-e5c5a41088be.png)

While the same error is printed as I `console.warn`'d it, it no longer throws and therefore doesn't fail the job

It also passes [on current PR](https://github.com/bahmutov/npm-install/pull/40/checks), but these were all cache hits, probably because I was testing on this branch before.
As far as I understand, there is no way to force cache bust without changing the key in GitHub Actions right now (no API for it to be exact), which makes integration testing cache misses a bit difficult. If we were to add actual integration tests as opposed to this "self-CI integration test" as I've done here then we could randomize cache key there to force a cache miss