### PR TITLE
format: add prettier scripts, prettierignore, pre-commit, and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
 
       - run: node -v
       - run: npm ci
+      - run: npm run format:check
       - run: npm test
 
   release:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# artifacts
+dist/
+# unsupported formats
+yarn.lock
+.gitignore
+.prettierignore
+.npmrc

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "GitHub Action for install npm dependencies with caching without any configuration",
   "main": "dist/index.js",
   "scripts": {
+    "format": "prettier --write './**/*'",
+    "format:check": "prettier --check './**/*'",
     "test": "npm run unit",
     "unit": "mocha test/helper 'test/*spec.js'",
     "pretest": "npm run build",
@@ -54,7 +56,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run build"
+      "pre-commit": "npm run format:check && npm run build && npm run test"
     }
   },
   "files": [

--- a/test/action-spec.js
+++ b/test/action-spec.js
@@ -120,7 +120,10 @@ describe('action', () => {
       expect(this.exec).to.be.calledOnceWithExactly(quote(pathToNpm), ['ci'], {
         cwd
       })
-      expect(this.saveCache).to.be.calledOnceWithExactly(npmCachePaths, cacheKey)
+      expect(this.saveCache).to.be.calledOnceWithExactly(
+        npmCachePaths,
+        cacheKey
+      )
     })
   })
 


### PR DESCRIPTION
## Description

- format all prettier supported files, ignore dist/ artifacts and ignore
  files prettier doesn't support
  - prettier also formats YAML, JSON, and Markdown here and has support
    for a few more too

- run format check on pre-commit and on CI

- format one file that hadn't passed check

## Review Notes

Not sure why there wasn't a script, pre-commit, or CI check before. Prettier was a devDep already.

## Testing

Runs in pre-commit and CI now, fixed that one file