### PR TITLE
optim: add secondary cache key if lock hash doesn't exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2863,12 +2863,14 @@ const getCacheParams = ({
   const o = {}
   if (useYarn) {
     o.inputPaths = [path.join(homeDirectory, '.cache', 'yarn')]
-    o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
-    o.restoreKeys = [o.primaryKey]
+    const archKey = `yarn-${platformAndArch}-`
+    o.primaryKey = `${archKey}${lockHash}`
+    o.restoreKeys = [o.primaryKey, archKey]
   } else {
     o.inputPaths = [npmCacheFolder]
-    o.primaryKey = `npm-${platformAndArch}-${lockHash}`
-    o.restoreKeys = [o.primaryKey]
+    const archKey = `npm-${platformAndArch}-`
+    o.primaryKey = `${archKey}${lockHash}`
+    o.restoreKeys = [o.primaryKey, archKey]
   }
   return o
 }

--- a/index.js
+++ b/index.js
@@ -145,12 +145,14 @@ const getCacheParams = ({
   const o = {}
   if (useYarn) {
     o.inputPaths = [path.join(homeDirectory, '.cache', 'yarn')]
-    o.primaryKey = `yarn-${platformAndArch}-${lockHash}`
-    o.restoreKeys = [o.primaryKey]
+    const archKey = `yarn-${platformAndArch}-`
+    o.primaryKey = `${archKey}${lockHash}`
+    o.restoreKeys = [o.primaryKey, archKey]
   } else {
     o.inputPaths = [npmCacheFolder]
-    o.primaryKey = `npm-${platformAndArch}-${lockHash}`
-    o.restoreKeys = [o.primaryKey]
+    const archKey = `npm-${platformAndArch}-`
+    o.primaryKey = `${archKey}${lockHash}`
+    o.restoreKeys = [o.primaryKey, archKey]
   }
   return o
 }

--- a/test/action-spec.js
+++ b/test/action-spec.js
@@ -28,7 +28,8 @@ describe('action', () => {
     const pathToYarn = '/path/to/yarn'
     const yarnFilename = path.join(cwd, 'yarn.lock')
     const yarnCachePaths = [path.join(homedir, '.cache', 'yarn')]
-    const cacheKey = 'yarn-platform-arch-hash-from-yarn-lock-file'
+    const archCacheKey = 'yarn-platform-arch-'
+    const cacheKey = `${archCacheKey}hash-from-yarn-lock-file`
 
     beforeEach(function() {
       sandbox
@@ -62,7 +63,7 @@ describe('action', () => {
       expect(this.restoreCache).to.be.calledOnceWithExactly(
         yarnCachePaths,
         cacheKey,
-        [cacheKey]
+        [cacheKey, archCacheKey]
       )
       expect(this.exec).to.be.calledOnceWithExactly(
         quote(pathToYarn),
@@ -81,7 +82,8 @@ describe('action', () => {
     const packageLockFilename = path.join(cwd, 'package-lock.json')
     const npmCachePaths = [path.join(homedir, '.npm')]
     const pathToNpm = '/path/to/npm'
-    const cacheKey = 'npm-platform-arch-hash-from-package-lock-file'
+    const archCacheKey = 'npm-platform-arch-'
+    const cacheKey = `${archCacheKey}hash-from-package-lock-file`
 
     beforeEach(function() {
       sandbox
@@ -115,7 +117,7 @@ describe('action', () => {
       expect(this.restoreCache).to.be.calledOnceWithExactly(
         npmCachePaths,
         cacheKey,
-        [cacheKey]
+        [cacheKey, archCacheKey]
       )
       expect(this.exec).to.be.calledOnceWithExactly(quote(pathToNpm), ['ci'], {
         cwd
@@ -158,7 +160,10 @@ describe('action', () => {
       expect(restoreCache).to.have.been.calledOnceWithExactly({
         inputPaths: [path.join(homedir, '.npm')],
         primaryKey: 'npm-platform-arch-hash-from-package-json',
-        restoreKeys: ['npm-platform-arch-hash-from-package-json']
+        restoreKeys: [
+          'npm-platform-arch-hash-from-package-json',
+          'npm-platform-arch-'
+        ]
       })
 
       expect(this.exec).to.have.been.calledOnceWithExactly(
@@ -183,7 +188,10 @@ describe('action', () => {
       const cacheParams = {
         inputPaths: [path.join(homedir, '.npm')],
         primaryKey: 'npm-platform-arch-hash-from-package-json',
-        restoreKeys: ['npm-platform-arch-hash-from-package-json']
+        restoreKeys: [
+          'npm-platform-arch-hash-from-package-json',
+          'npm-platform-arch-'
+        ]
       }
       expect(restoreCache).to.have.been.calledOnceWithExactly(cacheParams)
 


### PR DESCRIPTION
## Description

- follows `restore-keys` example from
  https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
  and https://github.com/actions/cache/blame/59a8d125e7227efbef01813bf1ecf30fa8b6bd8c/examples.md#L234
  - these specify to use the key with everything but the lock hash in
    case the specific cache with the lock hash doesn't exist
    - the thought being that a partial cache is better than no cache

## Tags

Doesn't quite resolve, but should make things like #28 happen less. #26 would still be good to solve

## Review Notes

Unclear why the primary key is also used duplicatively as a restore key?