### PR TITLE
optim: only build once on precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format:check && npm run build && npm run test"
+      "pre-commit": "npm run format:check && npm run test"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format:check && npm run test"
+      "pre-commit": "npm run format:check && npm test"
     }
   },
   "files": [


### PR DESCRIPTION
## Description

- I added `test` to precommit before and left in `build` as I didn't
  see that `test` called `build`, but I must've missed `pretest` that
  does so
  - so remove the extraneous `build` from precommit

## Tags

In #41, I added the `test` to precommit and accidentally left in `build` 