### PR TITLE
fix: set absolute working dir when running the install

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2883,7 +2883,7 @@ const install = (opts = {}) => {
   }
 
   const options = {
-    cwd: opts.workingDirectory
+    cwd: path.resolve(opts.workingDirectory)
   }
 
   if (shouldUseYarn) {
@@ -3006,15 +3006,16 @@ const npmInstallAction = async () => {
   const usePackageLock = getInputBool('useLockFile', true)
   core.debug(`usePackageLock? ${usePackageLock}`)
 
+  // Note: working directory for "actions/exec" should be absolute
+
   const wds = core.getInput('working-directory') || process.cwd()
+
   const workingDirectories = wds
     .split('\n')
     .map(s => s.trim())
     .filter(Boolean)
 
-  core.debug(
-    `iterating over working ${workingDirectories.length} directorie(s)`
-  )
+  core.debug(`iterating over working ${workingDirectories.length} dis(s)`)
 
   for (const workingDirectory of workingDirectories) {
     await api.utils.installInOneFolder({ usePackageLock, workingDirectory })

--- a/dist/index.js
+++ b/dist/index.js
@@ -3015,7 +3015,7 @@ const npmInstallAction = async () => {
     .map(s => s.trim())
     .filter(Boolean)
 
-  core.debug(`iterating over working ${workingDirectories.length} dis(s)`)
+  core.debug(`iterating over working ${workingDirectories.length} folder(s)`)
 
   for (const workingDirectory of workingDirectories) {
     await api.utils.installInOneFolder({ usePackageLock, workingDirectory })

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ const npmInstallAction = async () => {
     .map(s => s.trim())
     .filter(Boolean)
 
-  core.debug(`iterating over working ${workingDirectories.length} dis(s)`)
+  core.debug(`iterating over working ${workingDirectories.length} folder(s)`)
 
   for (const workingDirectory of workingDirectories) {
     await api.utils.installInOneFolder({ usePackageLock, workingDirectory })

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const install = (opts = {}) => {
   }
 
   const options = {
-    cwd: opts.workingDirectory
+    cwd: path.resolve(opts.workingDirectory)
   }
 
   if (shouldUseYarn) {
@@ -204,15 +204,16 @@ const npmInstallAction = async () => {
   const usePackageLock = getInputBool('useLockFile', true)
   core.debug(`usePackageLock? ${usePackageLock}`)
 
+  // Note: working directory for "actions/exec" should be absolute
+
   const wds = core.getInput('working-directory') || process.cwd()
+
   const workingDirectories = wds
     .split('\n')
     .map(s => s.trim())
     .filter(Boolean)
 
-  core.debug(
-    `iterating over working ${workingDirectories.length} directorie(s)`
-  )
+  core.debug(`iterating over working ${workingDirectories.length} dis(s)`)
 
   for (const workingDirectory of workingDirectories) {
     await api.utils.installInOneFolder({ usePackageLock, workingDirectory })

--- a/test/action-spec.js
+++ b/test/action-spec.js
@@ -12,7 +12,8 @@ const action = require('../index')
 const utils = action.utils
 
 describe('action', () => {
-  const cwd = '/path/to/mock/cwd'
+  // by resolving we normalize the folder on Linux and Windows CI
+  const cwd = path.resolve('/path/to/mock/cwd')
   const homedir = '/home/path/for/test/user'
 
   beforeEach(function() {

--- a/test/install-spec.js
+++ b/test/install-spec.js
@@ -2,6 +2,7 @@ const exec = require('@actions/exec')
 const core = require('@actions/core')
 const io = require('@actions/io')
 const quote = require('quote')
+const path = require('path')
 
 const action = require('../index')
 
@@ -15,6 +16,34 @@ describe('install command', () => {
 
   context('using Yarn', () => {
     const pathToYarn = '/path/to/yarn'
+
+    it('uses absolute working directory', async function() {
+      const opts = {
+        useYarn: true,
+        usePackageLock: true,
+        // only use relative path
+        workingDirectory: 'directory',
+        npmCacheFolder
+      }
+      sandbox
+        .stub(io, 'which')
+        .withArgs('yarn')
+        .resolves(pathToYarn)
+      sandbox
+        .stub(path, 'resolve')
+        .withArgs('directory')
+        .returns(workingDirectory)
+
+      await action.utils.install(opts)
+      expect(
+        this.exec,
+        'to use absolute working directory'
+      ).to.have.been.calledOnceWithExactly(
+        quote(pathToYarn),
+        ['--frozen-lockfile'],
+        { cwd: workingDirectory }
+      )
+    })
 
     it('and lock file', async function() {
       const opts = {
@@ -60,6 +89,33 @@ describe('install command', () => {
 
     beforeEach(function() {
       this.exportVariable = sandbox.stub(core, 'exportVariable')
+    })
+
+    it('uses absolute working directory', async function() {
+      const opts = {
+        useYarn: false,
+        usePackageLock: true,
+        // only use relative path
+        workingDirectory: 'directory',
+        npmCacheFolder
+      }
+      sandbox
+        .stub(io, 'which')
+        .withArgs('npm')
+        .resolves(pathToNpm)
+      sandbox
+        .stub(path, 'resolve')
+        .withArgs('directory')
+        .returns(workingDirectory)
+
+      await action.utils.install(opts)
+
+      expect(
+        this.exec,
+        'to use absolute working directory'
+      ).to.have.been.calledOnceWithExactly(quote(pathToNpm), ['ci'], {
+        cwd: workingDirectory
+      })
     })
 
     it('installs using lock file', async function() {

--- a/test/install-spec.js
+++ b/test/install-spec.js
@@ -11,7 +11,8 @@ describe('install command', () => {
     this.exec = sandbox.stub(exec, 'exec').resolves()
   })
 
-  const workingDirectory = '/current/working/directory'
+  // by resolving we normalize the folder on Linux and Windows CI
+  const workingDirectory = path.resolve('/current/working/directory')
   const npmCacheFolder = '/path/to/user/cache'
 
   context('using Yarn', () => {


### PR DESCRIPTION
- closes #51

While I could not recreate the same failure in the example, I have seen a similar problem in cypress-io/github-action where relative working directory was a problem for finding `npm`