### PR TITLE
fix: actually support no lockfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const installInOneFolder = ({ usePackageLock, workingDirectory }) => {
   core.debug(`working directory ${workingDirectory}`)
 
   const lockInfo = getLockFilename(usePackageLock)(workingDirectory)
-  const lockHash = hasha.fromFileSync(lockInfo.lockFilename)
+  const lockHash = usePackageLock ? hasha.fromFileSync(lockInfo.lockFilename) : 'no-lockfile'
   if (!lockHash) {
     throw new Error(
       `could not compute hash from file "${lockInfo.lockFilename}"`


### PR DESCRIPTION
Currently `usePackageLock: false` does not work: https://github.com/kentcdodds/generator-kcd-oss/runs/1353406484?check_suite_focus=true

I haven't tested this thoroughly, but I think this should fix it.