### PR TITLE
fix: detect and handle the ReserveCacheError

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2852,7 +2852,7 @@ const saveCachedNpm = npmCache => {
     .catch(err => {
       // don't throw an error if cache already exists, which may happen due to
       // race conditions
-      if (err.message.includes('Cache already exists')) {
+      if (err instanceof cache.ReserveCacheError) {
         console.warn(err.message)
         return -1
       }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const saveCachedNpm = npmCache => {
     .catch(err => {
       // don't throw an error if cache already exists, which may happen due to
       // race conditions
-      if (err.message.includes('Cache already exists')) {
+      if (err instanceof cache.ReserveCacheError) {
         console.warn(err.message)
         return -1
       }


### PR DESCRIPTION
Error message was changed.

https://github.com/thinca/wtrans/runs/1530397560?check_suite_focus=true#step:5:22

> ReserveCacheError: Unable to reserve cache with key npm-linux-x64-4c301f72b10746acea4e7e7d907f1d17198d0088509ea723a78a3452075cb7422b968978f488de3baf472e738c8164e6d887468d7b1074b3fe7352257d1a8fcd, another job may be creating this cache.

When this happens, `cache.ReserveCacheError` is thrown.