### PR TITLE
fix(core): fix useYarn logic in getLockFileName (See issues-95)

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,16 +121,16 @@ const getNow = () => new Date()
 
 const getLockFilename = usePackageLock => workingDirectory => {
   const packageFilename = path.join(workingDirectory, 'package.json')
+  const yarnFilename = path.join(workingDirectory, 'yarn.lock')
+  const useYarn = fs.existsSync(yarnFilename)
 
   if (!usePackageLock) {
     return {
-      useYarn: false,
+      useYarn,
       lockFilename: packageFilename
     }
   }
 
-  const yarnFilename = path.join(workingDirectory, 'yarn.lock')
-  const useYarn = fs.existsSync(yarnFilename)
   core.debug(`yarn lock file "${yarnFilename}" exists? ${useYarn}`)
 
   const npmShrinkwrapFilename = path.join(


### PR DESCRIPTION
Hey @bahmutov 

I believe this PR should address the issue highlighted in https://github.com/bahmutov/npm-install/issues/95

I have moved the logic which sets `yarnFilename`, and in turn `useYarn`. 

It now passes this value into the early return if `usePackageLock` is false. 

Is this the correct approach to handle the issue? 

Hope this helps! 

Thanks 

YenHub :o) 