### PR TITLE
feat: Add support for yarn berry

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -336,7 +336,9 @@ const npmInstallAction = async () => {
     // that all promises that we care about have successfully
     // resolved, so simply exit with success.
     // From: https://github.com/actions/cache/blob/a2ed59d39b352305bdd2f628719a53b2cc4f9613/src/saveImpl.ts#L96
-    process.exit(0)
+    if (process.env.NODE_ENV !== 'test') {
+      process.exit(0)
+    }
   } catch (err) {
     console.error(err)
     core.setFailed(err.message)

--- a/dist/index.js
+++ b/dist/index.js
@@ -192,6 +192,7 @@ const getLockFilename = usePackageLock => workingDirectory => {
 
 const getCacheParams = ({
   useYarn,
+  useYarnV1,
   useRollingCache,
   homeDirectory,
   npmCacheFolder,
@@ -209,7 +210,9 @@ const getCacheParams = ({
   let inputPaths, restoreKeys
 
   if (useYarn) {
-    inputPaths = [path.join(homeDirectory, '.cache', 'yarn')]
+    inputPaths = useYarnV1
+      ? [path.join(homeDirectory, '.cache', 'yarn')]
+      : [path.join(homeDirectory, '.yarn', 'berry', 'cache')]
     primaryKeySegments.unshift('yarn')
   } else {
     inputPaths = [npmCacheFolder]
@@ -276,6 +279,7 @@ const installInOneFolder = async ({
 
   const NPM_CACHE = getCacheParams({
     useYarn,
+    useYarnV1,
     homeDirectory,
     useRollingCache,
     npmCacheFolder: NPM_CACHE_FOLDER,

--- a/dist/index.js
+++ b/dist/index.js
@@ -110,6 +110,7 @@ const install = (opts = {}) => {
   }
 
   const shouldUseYarn = opts.useYarn
+  const shouldUseYarnV1 = opts.useYarnV1 ?? true
   const shouldUsePackageLock = opts.usePackageLock
   const npmCacheFolder = opts.npmCacheFolder
   if (!npmCacheFolder) {
@@ -134,7 +135,9 @@ const install = (opts = {}) => {
     return io.which('yarn', true).then(yarnPath => {
       console.log('yarn at "%s"', yarnPath)
 
-      const args = shouldUsePackageLock ? ['--frozen-lockfile'] : []
+      const args = shouldUsePackageLock
+        ? [shouldUseYarnV1 ? '--frozen-lockfile' : '--immutable']
+        : []
       core.debug(
         `yarn command: "${yarnPath}" ${args} ${JSON.stringify(options)}`
       )
@@ -232,7 +235,7 @@ const getCacheParams = ({
   return { primaryKey: primaryKeySegments.join('-'), inputPaths, restoreKeys }
 }
 
-const installInOneFolder = ({
+const installInOneFolder = async ({
   usePackageLock,
   workingDirectory,
   useRollingCache,
@@ -259,6 +262,13 @@ const installInOneFolder = ({
     core.debug('using NPM command, not using Yarn cache paths')
     useYarn = false
   }
+  let useYarnV1 = true
+  if (useYarn) {
+    const { stdout: yarnVersion } = await exec.getExecOutput('yarn', [
+      '--version'
+    ])
+    useYarnV1 = /^1/.test(yarnVersion)
+  }
 
   // enforce the same NPM cache folder across different operating systems
   const homeDirectory = os.homedir()
@@ -275,6 +285,7 @@ const installInOneFolder = ({
 
   const opts = {
     useYarn,
+    useYarnV1,
     usePackageLock,
     workingDirectory,
     npmCacheFolder: NPM_CACHE_FOLDER,

--- a/index.js
+++ b/index.js
@@ -329,7 +329,9 @@ const npmInstallAction = async () => {
     // that all promises that we care about have successfully
     // resolved, so simply exit with success.
     // From: https://github.com/actions/cache/blob/a2ed59d39b352305bdd2f628719a53b2cc4f9613/src/saveImpl.ts#L96
-    process.exit(0)
+    if (process.env.NODE_ENV !== 'test') {
+      process.exit(0)
+    }
   } catch (err) {
     console.error(err)
     core.setFailed(err.message)

--- a/index.js
+++ b/index.js
@@ -185,6 +185,7 @@ const getLockFilename = usePackageLock => workingDirectory => {
 
 const getCacheParams = ({
   useYarn,
+  useYarnV1,
   useRollingCache,
   homeDirectory,
   npmCacheFolder,
@@ -202,7 +203,9 @@ const getCacheParams = ({
   let inputPaths, restoreKeys
 
   if (useYarn) {
-    inputPaths = [path.join(homeDirectory, '.cache', 'yarn')]
+    inputPaths = useYarnV1
+      ? [path.join(homeDirectory, '.cache', 'yarn')]
+      : [path.join(homeDirectory, '.yarn', 'berry', 'cache')]
     primaryKeySegments.unshift('yarn')
   } else {
     inputPaths = [npmCacheFolder]
@@ -269,6 +272,7 @@ const installInOneFolder = async ({
 
   const NPM_CACHE = getCacheParams({
     useYarn,
+    useYarnV1,
     homeDirectory,
     useRollingCache,
     npmCacheFolder: NPM_CACHE_FOLDER,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "format": "prettier --write './**/*'",
     "format:check": "prettier --check './**/*'",
-    "test": "npm run unit",
+    "test": "NODE_ENV=test npm run unit",
     "unit": "mocha test/helper 'test/*spec.js'",
     "pretest": "npm run build",
     "build": "ncc build -o dist index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "format": "prettier --write './**/*'",
     "format:check": "prettier --check './**/*'",
-    "test": "NODE_ENV=test npm run unit",
+    "test": "npm run unit",
     "unit": "mocha test/helper 'test/*spec.js'",
     "pretest": "npm run build",
     "build": "ncc build -o dist index.js",

--- a/test/action-spec.js
+++ b/test/action-spec.js
@@ -55,6 +55,11 @@ describe('action', () => {
         .withArgs(yarnFilename)
         .returns('hash-from-yarn-lock-file')
 
+      sandbox
+        .stub(exec, 'getExecOutput')
+        .withArgs('yarn', ['--version'])
+        .resolves({ stdout: '1.22.19' })
+
       const cacheHit = false
       this.restoreCache = sandbox.stub(cache, 'restoreCache').resolves(cacheHit)
       this.saveCache = sandbox.stub(cache, 'saveCache').resolves()
@@ -316,6 +321,11 @@ describe('action', () => {
         .withArgs(yarnFilename)
         .returns('hash-from-yarn-lock-file')
 
+      sandbox
+        .stub(exec, 'getExecOutput')
+        .withArgs('yarn', ['--version'])
+        .resolves({ stdout: '1.22.19' })
+
       const cacheHit = false
       this.restoreCache = sandbox.stub(cache, 'restoreCache').resolves(cacheHit)
       this.saveCache = sandbox.stub(cache, 'saveCache').resolves()
@@ -448,6 +458,11 @@ describe('action', () => {
         .stub(hasha, 'fromFileSync')
         .withArgs(yarnFilename)
         .returns('hash-from-yarn-lock-file')
+
+      sandbox
+        .stub(exec, 'getExecOutput')
+        .withArgs('yarn', ['--version'])
+        .resolves({ stdout: '1.22.19' })
 
       const cacheHit = false
       this.restoreCache = sandbox.stub(cache, 'restoreCache').resolves(cacheHit)

--- a/test/install-spec.js
+++ b/test/install-spec.js
@@ -21,6 +21,7 @@ describe('install command', () => {
     it('uses absolute working directory', async function() {
       const opts = {
         useYarn: true,
+        useYarnV1: true,
         usePackageLock: true,
         // only use relative path
         workingDirectory: 'directory',
@@ -54,6 +55,7 @@ describe('install command', () => {
     it('and lock file', async function() {
       const opts = {
         useYarn: true,
+        useYarnV1: true,
         usePackageLock: true,
         workingDirectory,
         npmCacheFolder
@@ -73,6 +75,7 @@ describe('install command', () => {
     it('without lock file', async function() {
       const opts = {
         useYarn: true,
+        useYarnV1: true,
         usePackageLock: false,
         workingDirectory,
         npmCacheFolder
@@ -88,6 +91,26 @@ describe('install command', () => {
         { cwd: workingDirectory }
       )
     })
+
+    it('uses Yarn berry', async function() {
+      const opts = {
+        useYarn: true,
+        useYarnV1: false,
+        usePackageLock: true,
+        workingDirectory,
+        npmCacheFolder
+      }
+      sandbox
+        .stub(io, 'which')
+        .withArgs('yarn')
+        .resolves(pathToYarn)
+      await action.utils.install(opts)
+      expect(this.exec).to.have.been.calledOnceWithExactly(
+        quote(pathToYarn),
+        ['--immutable'],
+        { cwd: workingDirectory }
+      )
+    })
   })
 
   context('using NPM', () => {
@@ -100,6 +123,7 @@ describe('install command', () => {
     it('uses absolute working directory', async function() {
       const opts = {
         useYarn: false,
+        useYarnV1: false,
         usePackageLock: true,
         // only use relative path
         workingDirectory: 'directory',
@@ -127,6 +151,7 @@ describe('install command', () => {
     it('installs using lock file', async function() {
       const opts = {
         useYarn: false,
+        useYarnV1: false,
         usePackageLock: true,
         workingDirectory,
         npmCacheFolder
@@ -151,6 +176,7 @@ describe('install command', () => {
     it('installs without a lock file', async function() {
       const opts = {
         useYarn: false,
+        useYarnV1: false,
         usePackageLock: false,
         workingDirectory,
         npmCacheFolder
@@ -177,6 +203,7 @@ describe('install command', () => {
     it('calls exec directly', async function() {
       const opts = {
         useYarn: true,
+        useYarnV1: false,
         usePackageLock: true,
         // only use relative path
         workingDirectory: 'directory',


### PR DESCRIPTION
Hello!

This pull request adds support for Yarn Berry, the latest version of Yarn package manager. In Yarn Berry, [the `--frozen-lock-file` option has been deprecated and replaced with `--immutable`](https://yarnpkg.com/cli/install#details). I have updated the code to use the `--immutable` option and also adjusted the cache directory path to `$HOME/.yarn/berry/cache`.

I believe these changes are straightforward, but if you have any suggestions or improvements, please let me know. I'm open to feedback and would appreciate your insights. Thank you for considering these changes.
